### PR TITLE
ClusterSlots Config and ReadOnly 

### DIFF
--- a/cluster.go
+++ b/cluster.go
@@ -218,7 +218,7 @@ type CNode interface {
 // latency funcs return true if alls well, false if they should be marked as failing
 func defaultLatencyFunc(c *Client) bool {
 	cmd := c.Ping(context.Background())
-	if isLoadingError(cmd.err) {
+	if cmd.err != nil && isLoadingError(cmd.err) {
 		return false
 	}
 	return true

--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1006,6 +1006,66 @@ var _ = Describe("ClusterClient", func() {
 
 		assertClusterClient()
 	})
+
+	Describe("ClusterClient with ClusterSlots with multiple nodes per slot", func() {
+		BeforeEach(func() {
+			failover = true
+
+			opt = redisClusterOptions()
+			opt.ReadOnly = true
+			opt.ClusterSlots = func(ctx context.Context) ([]redis.ClusterSlot, error) {
+				slots := []redis.ClusterSlot{{
+					Start: 0,
+					End:   4999,
+					Nodes: []redis.ClusterNode{{
+						Addr: ":8220",
+					}, {
+						Addr: ":8223",
+					}},
+				}, {
+					Start: 5000,
+					End:   9999,
+					Nodes: []redis.ClusterNode{{
+						Addr: ":8221",
+					}, {
+						Addr: ":8224",
+					}},
+				}, {
+					Start: 10000,
+					End:   16383,
+					Nodes: []redis.ClusterNode{{
+						Addr: ":8222",
+					}, {
+						Addr: ":8225",
+					}},
+				}}
+				return slots, nil
+			}
+			client = cluster.newClusterClient(ctx, opt)
+
+			err := client.ForEachMaster(ctx, func(ctx context.Context, master *redis.Client) error {
+				return master.FlushDB(ctx).Err()
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = client.ForEachSlave(ctx, func(ctx context.Context, slave *redis.Client) error {
+				Eventually(func() int64 {
+					return client.DBSize(ctx).Val()
+				}, 30*time.Second).Should(Equal(int64(0)))
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			failover = false
+
+			err := client.Close()
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		assertClusterClient()
+	})
 })
 
 var _ = Describe("ClusterClient without nodes", func() {


### PR DESCRIPTION
You have to set the ReadOnly flag on the ClusterOptions to make it fall back to
non-master nodes on reads. For non-clustered situations where you have multiple
nodes in a single ClusterSlot, it made the non-master node useless because it would
never route requests to it and if you set ReadOnly=true it would issue a READONLY
command to it, which would fail.

See comment in code for more details.