### PR TITLE
Make cluster opt.ReadOnly be a *bool

### DIFF
--- a/cluster_test.go
+++ b/cluster_test.go
@@ -1026,7 +1026,7 @@ var _ = Describe("ClusterClient", func() {
 			failover = true
 
 			opt = redisClusterOptions()
-			opt.ReadOnly = true
+			opt.ReadOnly = redis.PtrBool(true)
 			opt.ClusterSlots = func(ctx context.Context) ([]redis.ClusterSlot, error) {
 				slots := []redis.ClusterSlot{{
 					Start: 0,

--- a/universal.go
+++ b/universal.go
@@ -71,7 +71,7 @@ func (o *UniversalOptions) Cluster() *ClusterOptions {
 		Password: o.Password,
 
 		MaxRedirects:   o.MaxRedirects,
-		ReadOnly:       o.ReadOnly,
+		ReadOnly:       &o.ReadOnly,
 		RouteByLatency: o.RouteByLatency,
 		RouteRandomly:  o.RouteRandomly,
 


### PR DESCRIPTION
This allows us to set it in the client to false if we truly want it to be false.
Not setting it means it can be set to true by setting RouteRandomly or RouteByLatency as usual.
This is to support Redislabs which don't allow the READONLY command at all (should be a noop, but alas)